### PR TITLE
Added Avery 6572 label description.

### DIFF
--- a/lib/prawn/types.yaml
+++ b/lib/prawn/types.yaml
@@ -34,6 +34,17 @@ Envelope10:
     left_margin: 36
     top_margin: 108
     bottom_margin: 208
+#Avery 6572
+Avery6572:
+    paper_size: LETTER
+    top_margin: 36
+    bottom_margin: 36
+    left_margin: 9
+    right_margin: 9
+    columns: 3
+    rows: 5
+    column_gutter: 9
+    row_gutter: 0
 
 TEST:
     left_margin: 123


### PR DESCRIPTION
This branch contains the additional label description for types.yaml.
