### PR TITLE
add possibility to pass custom label formats either as a hash or as a configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ This creates a document with a name from the names array in each label. The labe
 
 For a full list of examples, take a look in the `examples` folder.
 
+# Create custom labels
+
+So you will not need to fork the Gem just to have your own formats you can pass the library a file name or a hash as so:
+```ruby
+my_custom_types_file_name = File.join(File.dirname(__FILE__), "config/custom_types.yaml") 
+
+Prawn::Labels.generate("names.pdf", names, :custom_types => my_custom_types_file_name :type => "Avery5160") do |pdf, name|
+  pdf.text name
+end
+```
+or alternatively:
+```ruby
+my_custom_types  = {"Agipa119461"=>{"paper_size"=>"A4", "top_margin"=>36.57, "bottom_margin"=>0, "left_margin"=>20.551, "right_margin"=>20.551, "columns"=>3, "rows"=>8, "column_gutter"=>7.087, "row_gutter"=>0}} 
+
+Prawn::Labels.generate("names.pdf", names, :custom_types => my_custom_types, :type => "Agipa119461") do |pdf, name|
+  pdf.text name
+end
+```
+
 ## Contributors
 
 - [Jordan Byron](http://jordanbyron.com)

--- a/examples/custom_label.rb
+++ b/examples/custom_label.rb
@@ -1,0 +1,21 @@
+require File.join(File.dirname(__FILE__), "example_helper")
+
+fancy_names = ["Jordan", "Chris", "Jon", "Mike", "Kelly", "Bob", "Greg",
+               "Jordan", "Chris", "Jon", "Mike", "Kelly", "Bob", "Greg",
+               "Jordan", "Chris", "Jon", "Mike", "Kelly", "Bob", "Greg",
+               "Jordan", "Chris", "Jon", "Mike", "Kelly", "Bob", "Greg",
+               "Jordan", "Chris", "Jon", "Mike", "Kelly", "Bob", "Greg"]
+
+#define a custom label type
+my_custom_types  = {"Agipa119461"=>{"paper_size"=>"A4", "top_margin"=>36.57, "bottom_margin"=>0, "left_margin"=>20.551, "right_margin"=>20.551, "columns"=>3, "rows"=>8, "column_gutter"=>7.087, "row_gutter"=>0}} 
+
+Prawn::Labels.generate("custom_labels_1.pdf", fancy_names,  :custom_types => my_custom_types, :type => "Agipa119461") do |pdf, name|
+  pdf.text name
+end
+
+#use a configuration file for custom labels
+my_custom_types_file_name = File.join(File.dirname(__FILE__), "custom_label.yml") 
+
+Prawn::Labels.generate("custom_labels_2.pdf", fancy_names,  :custom_types => my_custom_types_file_name, :type => "Agipa119461") do |pdf, name|
+  pdf.text name
+end

--- a/examples/custom_label.yml
+++ b/examples/custom_label.yml
@@ -1,0 +1,11 @@
+# agipa 119641 labels, 63,5x33,9 mm coins arrondis - 3x8 = 24 per sheet
+Agipa119461:
+    paper_size: A4
+    top_margin: 36.57
+    bottom_margin: 0
+    left_margin: 20.551
+    right_margin: 20.551
+    columns: 3
+    rows: 8
+    column_gutter: 7.087
+    row_gutter: 0

--- a/lib/prawn/labels.rb
+++ b/lib/prawn/labels.rb
@@ -25,6 +25,15 @@ module Prawn
       types_file = File.join(File.dirname(__FILE__), 'types.yaml')
       types      = YAML.load_file(types_file)
 
+
+      if options[:custom_types].is_a? Hash then
+        types.merge!(options[:custom_types])
+      else
+        if (options[:custom_types].is_a? String) && (File.exist? options[:custom_types])
+          types.merge!(YAML.load_file(options[:custom_types]))
+        end
+      end
+      
       unless @type = types[options[:type]]
         raise "Label Type Unknown '#{options[:type]}'"
       end

--- a/prawn-labels.gemspec
+++ b/prawn-labels.gemspec
@@ -1,4 +1,4 @@
-PRAWN_LABELS_VERSION = "0.11.2.2"
+PRAWN_LABELS_VERSION = "0.11.3.0"
 
 Gem::Specification.new do |spec|
   spec.name = "prawn-labels"


### PR DESCRIPTION
So it will not be needed to fork the gem or vendorize it just to use a custom format, also updated readme and examples to reflect change and bumped minor version
