### PR TITLE
Update specifications for Avery 5160

### DIFF
--- a/lib/prawn/types.yaml
+++ b/lib/prawn/types.yaml
@@ -16,14 +16,14 @@ Avery7160:
     row_gutter: 0
 # Avery 5160 family
 Avery5160:
-    paper_size: A4
+    paper_size: LETTER
     top_margin: 36
     bottom_margin: 36
     left_margin: 15.822
     right_margin: 15.822
     columns: 3
     rows: 10
-    column_gutter: 10
+    column_gutter: 15
     row_gutter: 0
 # Standard #10 envelope
 Envelope10:


### PR DESCRIPTION
The specifications for the out of the box 5160 template were a bit off.  The page size is standard letter 8.5 x 11.  I also massaged the column gutter to correctly fit this label type.
