### PR TITLE
Add note on how to define custom labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ Prawn::Labels.generate("names.pdf", names, :type => "QuarterSheet") do |pdf, nam
 end
 ```
 
+**Remember**: Prawn expects all [measurements](https://github.com/prawnpdf/prawn/blob/2f894ade8e6a97453a6a77fdf5c7400ca4dd7428/lib/prawn/measurements.rb) to be provided in Postscript points
+So either provide them in points or do:
+
+``` ruby
+include Prawn::Measurements 
+Prawn::Labels.types = {
+  "QuarterSheet" => {
+    "paper_size" => "A4",
+    "top_margin" => mm2pt(13),
+    "columns"    => 2,
+    "rows"       => 2
+}}
+```
+
 ### Prawn document options
 
 Prawn::Labels allows passing a hash of document options all the way through to Prawn. 


### PR DESCRIPTION
It took me a few tries before I figured it out I had to enter it in point sizes instead of mm. So by adding this small snippet in the readme, the next person might even have less work using this library.