### PR TITLE
Add an offset option and correct Avery7160 margin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,46 +14,6 @@ GEM
       ttfunk (~> 1.4.0)
     purdytest (1.0.0)
       minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
-      minitest (~> 2.2)
     ttfunk (1.4.0)
 
 PLATFORMS
@@ -63,3 +23,6 @@ DEPENDENCIES
   minitest
   prawn-labels!
   purdytest
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ Prawn::Labels.generate( "names.pdf", names, :type => "Avery5160",
 end
 ```
 
+### Offset text within each cell
+
+```ruby
+Prawn::Labels.generate( "names.pdf", names, :type => "Avery5160",
+                        :offset => [10,10]) do |pdf, name|
+  pdf.text name
+end
+```
+
+Offset is specified in points.  
+The current implementation of the offset option is incompatible with shrink-to-fit and vertical-text.
+
 ### Custom label types
 
 If the label type you need to use isn't defined in `prawn/labels/types.yaml`

--- a/lib/prawn/labels.rb
+++ b/lib/prawn/labels.rb
@@ -41,6 +41,9 @@ module Prawn
     end
 
     def initialize(data, options = {}, &block)
+      if (options[:shrink_to_fit] == true || options[:vertical_text] == true) && options[:offset] != nil
+        raise "Offset option is incompatible with shrink_to_fit and vertical text"
+      end
       unless @type = Labels.types[options[:type]]
         raise "Label Type Unknown '#{options[:type]}'"
       end
@@ -96,7 +99,12 @@ module Prawn
     def create_label(index, record, options = {},  &block)
       p = row_col_from_index(index)
 
-      shrink_text(record) if options[:shrink_to_fit] == true
+      if options[:shrink_to_fit] == true
+        shrink_text(record)
+        offset = [0,0]
+      else
+        offset = options[:offset] || [5.0, 5.0]
+      end
 
       b = @document.grid(p.first, p.last)
 
@@ -109,7 +117,9 @@ module Prawn
           end
         end
       else
-        @document.bounding_box b.top_left, :width => b.width, :height => b.height do
+        xo, yo = offset
+        x, y = b.top_left
+        @document.bounding_box [x+xo, y-yo], :width => b.width-xo, :height => b.height-yo  do
           yield @document, record
         end
       end

--- a/lib/prawn/types.yaml
+++ b/lib/prawn/types.yaml
@@ -7,7 +7,7 @@
 Avery7160:
     paper_size: A4
     top_margin: 43.9
-    bottom_margin: 0
+    bottom_margin: 43.9
     left_margin: 19.843
     right_margin: 19.843
     columns: 3

--- a/test/features/offset_option_test.rb
+++ b/test/features/offset_option_test.rb
@@ -1,0 +1,46 @@
+require_relative '../test_helper'
+
+describe "Offset test 1" do
+  let(:pdf_path) { "test/pdfs/offset_option.pdf" }
+
+  before { FileUtils.rm(pdf_path, :force => true) }
+
+  it "raises an error if used with vertical_text" do
+    names  = ["Jordan", "Chris", "Jon", "Mike"]
+
+    assert_raises(RuntimeError) do
+      Prawn::Labels.generate(pdf_path, names,type: "Avery5160", vertical_text: true , offset: [10,10]) do |pdf, name|
+        pdf.text name
+      end
+    end
+  end
+  
+  it "raises an error if used with shrink_to_fit" do
+    names  = ["Jordan", "Chris", "Jon", "Mike"]
+
+    assert_raises(RuntimeError) do
+      Prawn::Labels.generate(pdf_path, names,type: "Avery5160", shrink_to_fit: true , offset: [10,10]) do |pdf, name|
+        pdf.text name
+      end
+    end
+  end
+end
+
+describe "Offset test 2" do
+  let(:pdf_path) { "test/pdfs/offset_option.pdf" }
+
+  before { FileUtils.rm(pdf_path, :force => true) }
+
+  
+  it "writes an output file if used without shrink_to_fit and vertaival_text" do
+    names  = ["Jordan", "Chris", "Jon", "Mike"]
+
+    Prawn::Labels.generate(pdf_path, names,type: "Avery5160",  offset: [30,30]) do |pdf, name|
+      pdf.text name
+    end
+
+    File.exists?(pdf_path).must_equal true    
+    
+  end
+  
+end


### PR DESCRIPTION
Add the offset option to offset text within each cell.  See README for an example.

Update types.yaml by adding a bottom margin for Avery7160.